### PR TITLE
Add FastAPI backend and React frontend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# IHJ React + FastAPI
+
+This is a minimal example showing how to replace the original Streamlit app with a
+FastAPI backend and a React frontend.
+
+## Backend
+
+```
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+## Frontend
+
+The frontend uses Vite + React. To run it you'll need Node.js installed.
+
+```
+cd frontend
+npm install
+npm run start
+```
+
+Both services assume the PostgreSQL database configuration from the previous
+Streamlit version. Adjust environment variables `DB_HOST`, `DB_PORT`,
+`DB_NAME`, `DB_USER` and `DB_PASS` if necessary.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,22 @@
+from sqlalchemy import create_engine
+from urllib.parse import quote_plus
+import os
+
+DB_HOST = os.getenv("DB_HOST", "postgres")
+DB_PORT = os.getenv("DB_PORT", "5432")
+DB_NAME = os.getenv("DB_NAME", "ihj_database")
+DB_USER = os.getenv("DB_USER", "user")
+DB_PASS = os.getenv("DB_PASS", "pass")
+
+DATABASE_URL = (
+    f"postgresql+psycopg2://{DB_USER}:{quote_plus(DB_PASS)}@"
+    f"{DB_HOST}:{DB_PORT}/{DB_NAME}"
+)
+
+engine = create_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,
+    pool_recycle=300,
+    echo=False,
+    connect_args={"options": "-c search_path=dbo"},
+)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,66 @@
+from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel
+from sqlalchemy import text
+from .database import engine
+import yaml
+from yaml.loader import SafeLoader
+
+app = FastAPI(title="IHJ API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+with open("config.yaml", "r", encoding="utf-8") as f:
+    config = yaml.load(f, Loader=SafeLoader)
+
+
+def authenticate_user(username: str, password: str) -> bool:
+    users = config.get("credentials", {}).get("usernames", {})
+    if username in users and password == users[username].get("password"):
+        return True
+    return False
+
+
+class Equipamento(BaseModel):
+    equipamento: str
+
+
+@app.post("/login")
+def login(form_data: OAuth2PasswordRequestForm = Depends()):
+    if authenticate_user(form_data.username, form_data.password):
+        return {"access_token": form_data.username, "token_type": "bearer"}
+    raise HTTPException(status_code=401, detail="Invalid credentials")
+
+
+@app.get("/classes")
+def get_classes():
+    query = "SELECT DISTINCT classe FROM tb_caract"
+    with engine.connect() as conn:
+        df = conn.execute(text(query)).fetchall()
+    return [row[0] for row in df]
+
+
+@app.get("/equipamentos")
+def get_equipamentos(classe: str):
+    query = text("SELECT DISTINCT equipamento FROM tb_caract WHERE classe=:classe")
+    with engine.connect() as conn:
+        rows = conn.execute(query, {"classe": classe}).fetchall()
+    return [row[0] for row in rows]
+
+
+@app.post("/similaridade")
+def similaridade(data: Equipamento):
+    query = text(
+        "SELECT * FROM tb_caract WHERE classe IN (SELECT classe FROM tb_caract WHERE equipamento=:equip)"
+    )
+    with engine.connect() as conn:
+        df = conn.execute(query, {"equip": data.equipamento}).fetchall()
+    # TODO: implementar lógica real de similaridade
+    return {"result": [dict(row) for row in df]}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlalchemy
+psycopg2-binary
+pyyaml

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>IHJ Busca</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ihj-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+
+function App() {
+  const [classes, setClasses] = useState([])
+
+  async function loadClasses() {
+    const res = await fetch('http://localhost:8000/classes')
+    const data = await res.json()
+    setClasses(data)
+  }
+
+  return (
+    <div>
+      <h1>IHJ Busca de Equipamentos</h1>
+      <button onClick={loadClasses}>Carregar Classes</button>
+      <ul>
+        {classes.map(c => <li key={c}>{c}</li>)}
+      </ul>
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)


### PR DESCRIPTION
## Summary
- bootstrap FastAPI backend with database connection and basic routes
- add Dockerfile and requirements for backend
- include simple React frontend scaffold using Vite
- document how to run backend and frontend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872868a670c8326863f2dc48127a910